### PR TITLE
Fixed typed_config and wrong pointer to envoy yaml config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This tutorial runs envoy and backend server locally for testing. Envoy will run 
 
 The first step is to configure an oauth2 `client_id` and `client_secret`.  For google cloud, configure one [here](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid).
 
-For this tutorial, you can set the `Authorized Redirect Uri` value to `https://envoy.esodemoapp2.com:8081`.  
+For this tutorial, you can set the `Authorized Redirect Uri` value to `https://envoy.esodemoapp2.com:8081/callback`.  
 ![images/client_id.png](images/client_id.png)
 
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ First get the latest envoy binary:
 Then just run envoy
 
 ```
-./envoy --base-id 0 -c envoy.yaml
+./envoy --base-id 0 -c proxy.yaml
 ```
 
 #### Start backend service

--- a/proxy.yaml
+++ b/proxy.yaml
@@ -35,7 +35,7 @@ static_resources:
           http_filters:
           - name: envoy.filters.http.oauth2
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.oauth2.v3alpha.OAuth2
+              "@type": type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2
               config:
                 token_endpoint:
                   cluster: google_oauth2


### PR DESCRIPTION
The typed_config changed from type.googleapis.com/envoy.extensions.filters.http.oauth2.v3alpha.OAuth2 -> type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2.

The instructions in readme has the start command `./envoy --base-id 0 -c envoy.yaml` however no envoy.yaml exists in the project. Should be proxy.yaml.